### PR TITLE
Correcting argument in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ unified interface.
 ```
 
 ```julia
- f = OptimizationFunction(rosenbrock, x0, GalacticOptim.AutoForwardDiff(), p)
+ f = OptimizationFunction(rosenbrock, GalacticOptim.AutoForwardDiff(), p)
  prob = OptimizationProblem(f, x0, p)
  sol = solve(prob,BFGS())
 ```
@@ -58,7 +58,7 @@ choice.
 ### API Documentation
 
 ```julia
-OptimizationFunction(f, x, AutoForwardDiff(), p = DiffEqBase.NullParameters();
+OptimizationFunction(f, AutoForwardDiff(), p = DiffEqBase.NullParameters();
                      grad = nothing,
                      hes = nothing,
                      hv = nothing,


### PR DESCRIPTION
The code was not running by copy-paste from the `readme`, I found that the `x0` was not supposed to be there (based on the tests I could find)

I believe API documentation also needs to be updated, but I'm not sure.