### PR TITLE
Fixing jacobian and hessians of constraints

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -234,28 +234,15 @@ function __solve(prob::OptimizationProblem, opt::Optim.ConstrainedOptimizer;cb =
 	cons! = (res, θ) -> res .= f.cons(θ);
 
 	cons_j! = function(J, x)
-		if f.num_cons > 1
-			res = [zeros(1,size(J,2)) for i in 1:size(J,1)]
-			f.cons_j(res, x)
-			J = reduce(vcat,res)
-		else
-			f.cons_j(J, x)
-		end
+		f.cons_j(J, x)
 	end
 
 	cons_hl! = function (h, θ, λ)
-		if f.num_cons > 1
-			res = [similar(h) for i in 1:length(λ)]
-			f.cons_h(res, θ)
-			h .= zeros(size(h))
-			for i in 1:length(λ)
-				h += λ[i]*res[i]
-			end
-		else
-			f.cons_h(h, θ)
-			h += λ[1]*h
+		res = [similar(h) for i in 1:length(λ)]
+		f.cons_h(res, θ)
+		for i in 1:length(λ)
+			h .+= λ[i]*res[i]
 		end
-
 	end
 
 	lb = prob.lb === nothing ? [] : prob.lb


### PR DESCRIPTION
See discussion in https://github.com/SciML/GalacticOptim.jl/issues/59#issuecomment-710671888

I did not want to change how anything acts in the inferace. But the following could also be changed:
-The `res` needed for hessians of constraints is currently a vector of matrices, but a single matrix that gets reused should suffice.
-It should be easy to refactor a bit and get rid of manually having to pass number of constraints.