### PR TITLE
update nlopt in solve.jl 

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -431,13 +431,13 @@ function __init__()
             f = instantiate_function(prob.f,prob.u0,prob.f.adtype,prob.p)
 
             _loss = function(θ)
-                x = prob.f.f(θ, prob.p)
+                x = f.f(θ, prob.p)
                 return x[1]
             end
 
             fg! = function (θ,G)
                 if length(G) > 0
-                    prob.f.grad(G, θ)
+                    f.grad(G, θ)
                 end
 
                 return _loss(θ)

--- a/test/rosenbrock.jl
+++ b/test/rosenbrock.jl
@@ -95,7 +95,7 @@ sol = solve(prob, Opt(:LD_LBFGS, 2))
 @test 10*sol.minimum < l1
 
 sol = solve(prob, Opt(:G_MLSL_LDS, 2), nstart=2, local_method = Opt(:LD_LBFGS, 2), maxiters=10000)
-@test_broken 10*sol.minimum < l1
+@test 10*sol.minimum < l1
 
 # using MultistartOptimization
 # sol = solve(prob, MultistartOptimization.TikTak(100), local_method = NLopt.LD_LBFGS)

--- a/test/rosenbrock.jl
+++ b/test/rosenbrock.jl
@@ -50,7 +50,7 @@ prob = OptimizationProblem(optprob, x0, lcons = [-5.0], ucons = [10.0])
 sol = solve(prob, IPNewton())
 @test 10*sol.minimum < l1
 
-prob = OptimizationProblem(optprob, x0, lcons = [-Inf], ucons = [Inf], lb = [-500.0,-500.0], ub=[-50.0,-50.0])
+prob = OptimizationProblem(optprob, x0, lcons = [-Inf], ucons = [Inf], lb = [-500.0,-500.0], ub=[50.0,50.0])
 sol = solve(prob, IPNewton())
 @test sol.minimum < l1
 


### PR DESCRIPTION
Hi,

I hope this helps: There seems to be a small bug when using the NLopt solver, which should be fixed by this. 
The problem is that for gradient-based algorithms, the solver does not converge. It can be recreated with this example (on 0.4.4 and Julia 1.5.3): 

```
using GalacticOptim, NLopt
f(x,p) = x[1]^2 + 1.0 
x0  = [10.0]

obj = OptimizationFunction(f,GalacticOptim.AutoForwardDiff())
prob = OptimizationProblem(obj,x0)
sol = solve(prob,Opt(:LD_LBFGS,1))
```