### PR TITLE
Deleted warning

### DIFF
--- a/docs/src/tutorials/intro.md
+++ b/docs/src/tutorials/intro.md
@@ -23,14 +23,6 @@ code to get started is the following:
 Note that Optim.jl is a core dependency of GalaticOptim.jl. However, BlackBoxOptim.jl
 is not and must already be installed (see the list above).
 
-*Warning:* The output of the second optimization task (`BBO()`) is
-currently misleading in the sense that it returns `Status: failure
-(reached maximum number of iterations)`. However, convergence is actually
-reached and the confusing message stems from the reliance on the Optim.jl output
- struct (where the situation of reaching the maximum number of iterations is
-rightly regarded as a failure). The improved output struct will soon be
-implemented.
-
 The output of the first optimization task (with the `NelderMead()` algorithm)
 is given below:
 


### PR DESCRIPTION
This warning is no longer needed because the output struct has been improved.