### PR TITLE
Use maxfuncevals in BBO solve dispatch instead of maxsteps

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -368,7 +368,7 @@ function __init__()
                 return first(x)
             end
 
-            bboptre = !(isnothing(maxiters)) ? BlackBoxOptim.bboptimize(_loss;Method = opt.method, SearchRange = [(prob.lb[i], prob.ub[i]) for i in 1:length(prob.lb)], MaxSteps = maxiters, CallbackFunction = _cb, CallbackInterval = 0.0, kwargs...) : BlackBoxOptim.bboptimize(_loss;Method = opt.method, SearchRange = [(prob.lb[i], prob.ub[i]) for i in 1:length(prob.lb)], CallbackFunction = _cb, CallbackInterval = 0.0, kwargs...)
+            bboptre = !(isnothing(maxiters)) ? BlackBoxOptim.bboptimize(_loss;Method = opt.method, SearchRange = [(prob.lb[i], prob.ub[i]) for i in 1:length(prob.lb)], MaxFuncEvals = maxiters, CallbackFunction = _cb, CallbackInterval = 0.0, kwargs...) : BlackBoxOptim.bboptimize(_loss;Method = opt.method, SearchRange = [(prob.lb[i], prob.ub[i]) for i in 1:length(prob.lb)], CallbackFunction = _cb, CallbackInterval = 0.0, kwargs...)
 
             SciMLBase.build_solution(prob, opt, BlackBoxOptim.best_candidate(bboptre),
                                      BlackBoxOptim.best_fitness(bboptre); original=bboptre)


### PR DESCRIPTION
When using `data` with BBO because of num of function calls (hence callback calls) was not set to maxiters (length of data) it was iterating through the data and erroring out.