### PR TITLE
Made NLopt.jl interface properly handle options & minor changes to MOI

### DIFF
--- a/docs/src/global_optimizers/global.md
+++ b/docs/src/global_optimizers/global.md
@@ -51,7 +51,7 @@ Recommend `BBO()`.
 
 ## NLopt.jl
 
-NLopt.jl algorithms are chosen via `NLopt.Opt(:algname)`. Consult the
+NLopt.jl algorithms are chosen via `NLopt.Opt(:algname, nparameter)` or `NLO(:algname)` where `nparameter` is the number of parameters to be optimized . Consult the
 [NLopt Documentation](https://nlopt.readthedocs.io/en/latest/NLopt_Algorithms/)
 for more information on the algorithms. Possible algorithm names are:
 
@@ -61,3 +61,40 @@ for more information on the algorithms. Possible algorithm names are:
 * `:G_MLSL_LDS`
 * `:GD_STOGO`
 * `:GN_ESCH`
+
+The following optimizer parameters can be set as `kwargs`:
+
+* `stopval`
+* `ftol_rel`
+* `ftol_abs`
+* `xtol_rel`
+* `xtol_abs`
+* `constrtol_abs`
+* `maxeval`
+* `maxtime`
+* `initial_step`
+* `population`
+* `vector_storage`
+
+Running an optimisation with `:GN_DIRECT` with setting the number iterations via the common argument `maxiters` and `NLopt.jl`-specific parameters such as the maximum time to perform the optimisation via `maxtime`:
+```julia
+rosenbrock(x, p) =  (p[1] - x[1])^2 + p[2] * (x[2] - x[1]^2)^2
+x0 = zeros(2)
+p  = [1.0, 100.0]
+f = OptimizationFunction(rosenbrock, GalacticOptim.AutoForwardDiff())
+prob = OptimizationProblem(f, x0, p, lb = [-1.0,-1.0], ub = [1.0,1.0])
+sol = solve(prob, NLO(:GN_DIRECT), maxiters=100000, maxtime=1000.0)
+```
+
+For algorithms such as `:G_MLSL` `:G_MLSL_LDS` also a local optimiser needs to be chosen which is done via `NLopt.Opt(:algname, nparameter)` or `NLO(:algname)` passed to the `local_method` argument of `solve`. The number iterations for the local optimiser are set via `local_maxiters` and the local optimiser parameters as listed above are set via a `NamedTuple` passed to the `local_options` argument of solve.
+
+Running an optimisation with `:G_MLSL_LDS` with setting the number iterations via the common argument `maxiters` and `NLopt.jl`-specific parameters such the number of local optimisation and maximum time to perform the optimisation via `population` and `maxtime` respectively and additionally setting the local optimizer to `:LN_NELDERMEAD`. The local optimizer maximum iterations are set via `local_maxiters`:
+
+```julia
+rosenbrock(x, p) =  (p[1] - x[1])^2 + p[2] * (x[2] - x[1]^2)^2
+x0 = zeros(2)
+p  = [1.0, 100.0]
+f = OptimizationFunction(rosenbrock, GalacticOptim.AutoForwardDiff())
+prob = OptimizationProblem(f, x0, p, lb = [-1.0,-1.0], ub = [1.0,1.0])
+sol = solve(prob, NLO(:G_MLSL_LDS), local_method = NLO(:LN_NELDERMEAD), local_maxiters=10000, maxiters=10000, maxtime=1000.0, population=10)
+```

--- a/docs/src/global_optimizers/global.md
+++ b/docs/src/global_optimizers/global.md
@@ -51,7 +51,7 @@ Recommend `BBO()`.
 
 ## NLopt.jl
 
-NLopt.jl algorithms are chosen via `NLopt.Opt(:algname, nparameter)` or `NLO(:algname)` where `nparameter` is the number of parameters to be optimized . Consult the
+NLopt.jl algorithms are chosen via `NLopt.Opt(:algname, nstates)` or `NLO(:algname)` where `nstates` is the number of states to be optimized . Consult the
 [NLopt Documentation](https://nlopt.readthedocs.io/en/latest/NLopt_Algorithms/)
 for more information on the algorithms. Possible algorithm names are:
 

--- a/docs/src/global_optimizers/global_constrained.md
+++ b/docs/src/global_optimizers/global_constrained.md
@@ -32,9 +32,23 @@
 
 ## NLopt.jl
 
-NLopt.jl algorithms are chosen via `NLopt.Opt(:algname)`. Consult the
+NLopt.jl algorithms are chosen via `NLopt.Opt(:algname, nparameter)` or `NLO(:algname)` where `nparameter` is the number of parameters to be optimized . Consult the
 [NLopt Documentation](https://nlopt.readthedocs.io/en/latest/NLopt_Algorithms/)
 for more information on the algorithms. Possible algorithm names are:
 
 * `:GN_AGS` (handles inequalities but not equalities)
 * `:GN_ISRES`
+
+The following optimizer parameters can be set as `kwargs`:
+
+* `stopval`
+* `ftol_rel`
+* `ftol_abs`
+* `xtol_rel`
+* `xtol_abs`
+* `constrtol_abs`
+* `maxeval`
+* `maxtime`
+* `initial_step`
+* `population`
+* `vector_storage`

--- a/docs/src/local_optimizers/local_constrained.md
+++ b/docs/src/local_optimizers/local_constrained.md
@@ -107,7 +107,7 @@ sol = solve(prob, opt)
 
 ## NLopt.jl
 
-NLopt.jl algorithms are chosen via `NLopt.Opt(:algname)`. Consult the
+NLopt.jl algorithms are chosen via `NLopt.Opt(:algname, nparameter)` or `NLO(:algname)` where `nparameter` is the number of parameters to be optimized . Consult the
 [NLopt Documentation](https://nlopt.readthedocs.io/en/latest/NLopt_Algorithms/)
 for more information on the algorithms. Possible algorithm names are:
 
@@ -123,3 +123,27 @@ for more information on the algorithms. Possible algorithm names are:
 * `:LD_VAR1`
 * `:AUGLAG`
 * `:AUGLAG_EQ`
+
+The following optimizer parameters can be set as `kwargs`:
+
+* `stopval`
+* `ftol_rel`
+* `ftol_abs`
+* `xtol_rel`
+* `xtol_abs`
+* `constrtol_abs`
+* `maxeval`
+* `maxtime`
+* `initial_step`
+* `population`
+* `vector_storage`
+
+Running an optimisation with `:GN_DIRECT` with setting the number iterations via the common argument `maxiters` and `NLopt.jl`-specific parameters such as the maximum time to perform the optimisation via `maxtime`:
+```julia
+rosenbrock(x, p) =  (p[1] - x[1])^2 + p[2] * (x[2] - x[1]^2)^2
+x0 = zeros(2)
+p  = [1.0, 100.0]
+f = OptimizationFunction(rosenbrock, GalacticOptim.AutoForwardDiff())
+prob = OptimizationProblem(f, x0, p, lb = [-1.0,-1.0], ub = [1.0,1.0])
+sol = solve(prob, NLO(:LD_LBFGS), maxiters=10000, maxtime=1000.0)
+```

--- a/docs/src/local_optimizers/local_derivative_free.md
+++ b/docs/src/local_optimizers/local_derivative_free.md
@@ -57,7 +57,7 @@ The following special keyword arguments can be used with Optim.jl optimizers:
 
 ## NLopt.jl
 
-NLopt.jl algorithms are chosen via `NLopt.Opt(:algname)`. Consult the
+NLopt.jl algorithms are chosen via `NLopt.Opt(:algname, nparameter)` or `NLO(:algname)` where `nparameter` is the number of parameters to be optimized . Consult the
 [NLopt Documentation](https://nlopt.readthedocs.io/en/latest/NLopt_Algorithms/)
 for more information on the algorithms. Possible algorithm names are:
 
@@ -68,3 +68,27 @@ for more information on the algorithms. Possible algorithm names are:
 * `LN_SBPLX`
 * `LD_MMA`
 * `LD_CCSAQ`
+
+The following optimizer parameters can be set as `kwargs`:
+
+* `stopval`
+* `ftol_rel`
+* `ftol_abs`
+* `xtol_rel`
+* `xtol_abs`
+* `constrtol_abs`
+* `maxeval`
+* `maxtime`
+* `initial_step`
+* `population`
+* `vector_storage`
+
+Running an optimisation with `:GN_DIRECT` with setting the number iterations via the common argument `maxiters` and `NLopt.jl`-specific parameters such as the maximum time to perform the optimisation via `maxtime`:
+```julia
+rosenbrock(x, p) =  (p[1] - x[1])^2 + p[2] * (x[2] - x[1]^2)^2
+x0 = zeros(2)
+p  = [1.0, 100.0]
+f = OptimizationFunction(rosenbrock, GalacticOptim.AutoForwardDiff())
+prob = OptimizationProblem(f, x0, p, lb = [-1.0,-1.0], ub = [1.0,1.0])
+sol = solve(prob, NLO(:LN_NELDERMEAD), maxiters=10000, maxtime=1000.0)
+```

--- a/src/solve/moi.jl
+++ b/src/solve/moi.jl
@@ -120,7 +120,7 @@ function __solve(prob::OptimizationProblem, opt::Union{MOI.AbstractOptimizer, MO
     if MOI.get(optimizer, MOI.ResultCount()) >= 1
         minimizer = MOI.get(optimizer, MOI.VariablePrimal(), θ)
         minimum = MOI.get(optimizer, MOI.ObjectiveValue())
-        ret = MOI.get(optimizer, MOI.TerminationStatus())
+        ret = Symbol(string(MOI.get(optimizer, MOI.TerminationStatus())))
     else
         minimizer = fill(NaN, num_variables)
         minimum = NaN

--- a/src/solve/moi.jl
+++ b/src/solve/moi.jl
@@ -120,9 +120,11 @@ function __solve(prob::OptimizationProblem, opt::Union{MOI.AbstractOptimizer, MO
     if MOI.get(optimizer, MOI.ResultCount()) >= 1
         minimizer = MOI.get(optimizer, MOI.VariablePrimal(), θ)
         minimum = MOI.get(optimizer, MOI.ObjectiveValue())
+        ret = MOI.get(optimizer, MOI.TerminationStatus())
     else
         minimizer = fill(NaN, num_variables)
         minimum = NaN
+        ret= :Default
     end
-    SciMLBase.build_solution(prob, opt, minimizer, minimum; original=nothing)
+    SciMLBase.build_solution(prob, opt, minimizer, minimum; original=optimizer, retcode=ret)
 end

--- a/src/solve/nlopt.jl
+++ b/src/solve/nlopt.jl
@@ -1,6 +1,15 @@
-function __solve(prob::OptimizationProblem, opt::NLopt.Opt;
-                 maxiters = nothing, nstart = 1,
-                 local_method = nothing,
+export NLO
+
+struct NLO
+    method::Symbol
+    NLO(method) = new(method)
+end
+
+function __solve(prob::OptimizationProblem, opt::Union{NLO, NLopt.Opt};
+                 maxiters = nothing,
+                 local_method::Union{NLO, NLopt.Opt, Nothing} = nothing,
+                 local_maxiters = nothing,
+                 local_options::Union{NamedTuple,Nothing} = nothing,
                  progress = false, kwargs...)
     local x
 
@@ -25,27 +34,61 @@ function __solve(prob::OptimizationProblem, opt::NLopt.Opt;
         return _loss(θ)
     end
 
-    NLopt.min_objective!(opt, fg!)
+    if isa(opt,NLopt.Opt)
+        if ndims(opt) != length(prob.u0)
+            error("Passed NLopt.Opt optimization dimension does not match OptimizationProblem dimension.")
+        end
+        model = opt
+    else
+        model = NLopt.Opt(opt.method, length(prob.u0))
+    end
+
+    NLopt.min_objective!(model, fg!)
 
     if prob.ub !== nothing
-        NLopt.upper_bounds!(opt, prob.ub)
+        NLopt.upper_bounds!(model, prob.ub)
     end
+
     if prob.lb !== nothing
-        NLopt.lower_bounds!(opt, prob.lb)
+        NLopt.lower_bounds!(model, prob.lb)
     end
+
     if !(isnothing(maxiters))
-        NLopt.maxeval!(opt, maxiters)
+        NLopt.maxeval!(model, maxiters)
     end
-    if nstart > 1 && local_method !== nothing
-        NLopt.local_optimizer!(opt, local_method)
-        if !(isnothing(maxiters))
-            NLopt.maxeval!(opt, nstart * maxiters)
+
+    if local_method !== nothing
+        if isa(local_method,NLopt.Opt)
+            if ndims(local_method) != length(prob.u0)
+                error("Passed local NLopt.Opt optimization dimension does not match OptimizationProblem dimension.")
+            end
+        else
+            local_method = NLopt.Opt(local_method.method, length(prob.u0))
         end
+
+        if !(isnothing(local_maxiters))
+            NLopt.maxeval!(local_method, local_maxiters)
+        end
+
+        if !isnothing(local_options)
+            for j in Dict(pairs(local_options))
+                eval(Meta.parse("NLopt."*string(j.first)*"!"))(local_method, j.second)
+            end
+        end
+
+        NLopt.local_optimizer!(model, local_method)
     end
+
+    # add optimiser options from kwargs
+    for j in kwargs
+        eval(Meta.parse("NLopt."*string(j.first)*"!"))(model, j.second)
+    end
+
+    # print(model)
 
     t0 = time()
-    (minf,minx,ret) = NLopt.optimize(opt, prob.u0)
+    (minf,minx,ret) = NLopt.optimize(model, prob.u0)
     _time = time()
 
-    SciMLBase.build_solution(prob, opt, minx, minf; original=nothing)
+    SciMLBase.build_solution(prob, opt, minx, minf; original=model, retcode=ret)
 end

--- a/src/solve/nonconvex.jl
+++ b/src/solve/nonconvex.jl
@@ -1,0 +1,96 @@
+export NC
+
+struct NC
+    method::Symbol
+    NC(method) = new(method)
+end
+
+
+function __solve(prob::OptimizationProblem, opt::NC;
+                 maxiters = nothing,
+                 local_method = nothing,
+                 local_maxiters = nothing,
+                 local_options= Union{Nothing,NamedTuple},
+                 integer=nothing, kwargs...)
+    local x
+
+    if !(isnothing(maxiters)) && maxiters <= 0.0
+        error("The number of maxiters has to be a non-negative and non-zero number.")
+    elseif !(isnothing(maxiters))
+        maxiters = convert(Int, maxiters)
+    end
+
+    f = instantiate_function(prob.f,prob.u0,prob.f.adtype,prob.p)
+
+    _loss = function(θ)
+        x = f.f(θ, prob.p)
+        return first(x)
+    end
+
+    # fg! = function (θ,G)
+    #     if length(G) > 0
+    #         f.grad(G, θ)
+    #     end
+
+    #     return _loss(θ)
+    # end
+
+    function ChainRulesCore.rrule(::typeof(_loss), x::AbstractVector)
+        val = _loss(x)
+        grad = similar(x) 
+        f.grad(grad, θ) #ForwardDiff.gradient(f, x)
+        val, Δ -> (NoTangent(), Δ * grad)
+    end
+
+
+    model = Nonconvex.Model(_loss)
+
+    if prob.lb !== nothing && prob.ub !== nothing
+        Nonconvex.addvar!(opt, prob.lb, prob.ub, init=prob.u0)
+    elseif prob.lb !== nothing && prob.ub !== nothing && !isnothing(integer)
+        Nonconvex.addvar!(opt, prob.lb, prob.ub, init=prob.u0, integer=integer)
+    else
+        error("Lower and upper bounds have to be defined for Nonconvex.jl.")
+    end
+
+    # if !(isnothing(maxiters))
+    #     NLopt.maxeval!(opt, maxiters)
+    # end
+    
+    # if nstart > 1 && local_method !== nothing
+    #     NLopt.local_optimizer!(opt, local_method)
+    #     if !(isnothing(maxiters))
+    #         NLopt.maxeval!(opt, nstart * maxiters)
+    #     end
+    # end
+    # set default options struct
+    if typeof(alg) <: Union{MMA, MMA87, MMA02, GCMMA}
+        options = MMAOptions(outer_maxiter=maxiters, kwargs...)
+    elseif typeof(alg) <: Union{IpoptAlg}
+        options = IpoptOptions(max_iter=maxiters, kwargs...)
+    elseif typeof(alg) <: Union{NLoptAlg}
+        options = NLoptOptions(maxeval=maxiters, kwargs...)
+    elseif typeof(alg) <: Union{AugLag}
+        options = AugLagOptions(max_iter=maxiters, kwargs...)
+    elseif typeof(alg) <: Union{JuniperIpoptAlg}
+        options = JuniperIpoptOptions(outer_maxiter=maxiters, kwargs...)
+    elseif typeof(alg) <: Union{PavitoIpoptCbcAlg}
+        options = PavitoIpoptCbcOptions(outer_maxiter=maxiters, kwargs...)
+    elseif typeof(alg) <: Union{HyperoptAlg(sampler = Hyperband())}
+        options = HyperoptOptions(iters=maxiters, kwargs...)
+    elseif typeof(alg) <: Union{HyperoptAlg(sampler = RandomSampler()), HyperoptAlg(sampler = LHSampler()), HyperoptAlg(sampler = CLHSampler()), HyperoptAlg(sampler = GPSampler())}
+        options = HyperoptOptions(iters=maxiters, kwargs...)
+    elseif typeof(alg) <: Union{BayesOptAlg}
+        options = BayesOptOptions(maxiter=maxiters, kwargs...)
+    elseif typeof(alg) <: Union{MTSAlg}
+        options = MMAOptions(outer_maxiter=maxiters, kwargs...)
+    end
+
+    # set maxiters
+
+    t0 = time()
+    nc_res = Nonconvex.optimize(model, opt.method, options=options)
+    _time = time()
+
+    SciMLBase.build_solution(prob, opt, nc_res.minimizer, nc_res.minimum; original=nc_res)
+end

--- a/test/rosenbrock.jl
+++ b/test/rosenbrock.jl
@@ -121,7 +121,21 @@ sol = solve(prob, NLopt.Opt(:LD_LBFGS, 2))
 sol = solve(prob, GalacticOptim.MOI.OptimizerWithAttributes(NLopt.Optimizer, "algorithm" => :LD_LBFGS))
 @test 10*sol.minimum < l1
 
-sol = solve(prob, NLopt.Opt(:G_MLSL_LDS, 2), nstart=2, local_method = NLopt.Opt(:LD_LBFGS, 2), maxiters=10000)
+sol = solve(prob, NLopt.Opt(:G_MLSL_LDS, 2), local_method = NLopt.Opt(:LD_LBFGS, 2), maxiters=10000)
+@test 10*sol.minimum < l1
+
+prob = OptimizationProblem(optprob, x0)
+sol = solve(prob, NLO(:LN_BOBYQA))
+@test 10*sol.minimum < l1
+
+sol = solve(prob, NLO(:LD_LBFGS))
+@test 10*sol.minimum < l1
+
+prob = OptimizationProblem(optprob, x0, lb=[-1.0, -1.0], ub=[0.8, 0.8])
+sol = solve(prob, NLO(:LD_LBFGS))
+@test 10*sol.minimum < l1
+
+sol = solve(prob, NLO(:G_MLSL_LDS), local_method = NLO(:LD_LBFGS), local_maxiters=10000, maxiters=10000, population=10)
 @test 10*sol.minimum < l1
 
 # using MultistartOptimization


### PR DESCRIPTION
NLopt.jl interface now takes option for global optimiser as kwargs and if a `local_method` is defined  maxiters and option for the local optimiser can be passed as `local_maxiters` and a NamedTuple to `local_options` respectively.

Moreover, the interface now takes both `NLopt.Opt` and the newly defined `NLO` type as optimiser input. The `NLO` type follows the same logic of `BBO`. 

Also I removed n_starts argument as it was passed to the optimiser and only used to multiply the `maxiters`. 

The NLopt `__solve` also passes `ret` to the `retcode` of `SciMLBase.SciMLBase.OptimizationSolution` and the NLopt model is passed to `original` field.

Additionally, for `MOI` interface now returns the `MOI.TerminationStatus()` via the `retcode` field and the optimised `MOI` problem via the `original` field of `SciMLBase.SciMLBase.OptimizationSolution`.

I have added some test for the changed interface