### PR TITLE
Fixed MOI warning

### DIFF
--- a/src/solve/moi.jl
+++ b/src/solve/moi.jl
@@ -1,4 +1,4 @@
-import MathOptInterface
+import .MathOptInterface
 const MOI = MathOptInterface
 
 struct MOIOptimizationProblem{T,F<:OptimizationFunction,uType,P} <: MOI.AbstractNLPEvaluator


### PR DESCRIPTION
A quick fix: Changed `import MathOptInterface` to `import .MathOptInterface` which caused warnings when loading `GalacticOptim` with `MOI`