### PR TITLE
Add NLopt maxsense support

### DIFF
--- a/src/solve/nlopt.jl
+++ b/src/solve/nlopt.jl
@@ -43,7 +43,6 @@ function __map_optimizer_args(prob::OptimizationProblem, opt::NLopt.Opt;
     for j in kwargs
         eval(Meta.parse("NLopt."*string(j.first)*"!"))(opt, j.second)
     end
-    prob.sense === MaxSense ? NLopt.max_objective!(opt, fg!) : NLopt.min_objective!(opt, fg!)
 
     if prob.ub !== nothing
         NLopt.upper_bounds!(opt, prob.ub)
@@ -115,7 +114,7 @@ function __solve(prob::OptimizationProblem, opt::Union{NLopt.Algorithm, NLopt.Op
         opt_setup = NLopt.Opt(opt, length(prob.u0))
     end
 
-    NLopt.min_objective!(opt_setup, fg!)
+    prob.sense === MaxSense ? NLopt.max_objective!(opt_setup, fg!) : NLopt.min_objective!(opt_setup, fg!)
 
     _map_optimizer_args(prob,opt_setup, maxiters=maxiters, maxtime=maxtime, abstol=abstol, reltol=reltol, local_method=local_method, local_maxiters =local_maxiters, local_options=local_options; kwargs...)
 

--- a/src/solve/nlopt.jl
+++ b/src/solve/nlopt.jl
@@ -43,6 +43,7 @@ function __map_optimizer_args(prob::OptimizationProblem, opt::NLopt.Opt;
     for j in kwargs
         eval(Meta.parse("NLopt."*string(j.first)*"!"))(opt, j.second)
     end
+    prob.sense === MaxSense ? NLopt.max_objective!(opt, fg!) : NLopt.min_objective!(opt, fg!)
 
     if prob.ub !== nothing
         NLopt.upper_bounds!(opt, prob.ub)

--- a/test/rosenbrock.jl
+++ b/test/rosenbrock.jl
@@ -100,6 +100,11 @@ import Ipopt
 sol = solve(prob, Ipopt.Optimizer())
 @test 10*sol.minimum < l1
 
+import NLopt
+sol = solve(prob, NLopt.Opt(:LN_BOBYQA, 2))
+@test 10*sol.minimum < l1
+
+
 optprob = OptimizationFunction(rosenbrock, GalacticOptim.AutoZygote())
 prob = OptimizationProblem(optprob, x0, _p; sense = GalacticOptim.MinSense)
 
@@ -109,7 +114,7 @@ sol = solve(prob, Ipopt.Optimizer())
 sol = solve(prob, GalacticOptim.MOI.OptimizerWithAttributes(Ipopt.Optimizer, "max_cpu_time" => 60.0))
 @test 10*sol.minimum < l1
 
-import NLopt
+
 prob = OptimizationProblem(optprob, x0)
 sol = solve(prob, NLopt.Opt(:LN_BOBYQA, 2))
 @test 10*sol.minimum < l1


### PR DESCRIPTION
Fixes #155. Even after spending some time on Optim I couldn't figure out a good way to support max sense for it and hence decided to not go ahead with that, in case a user wants to leverage it they can just negate the objective function on their end and have a similar outcome to Optim's `maximize`. 