### PR TITLE
Update global optimization status of MOI

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -32,7 +32,7 @@ packages.
 | Evolutionary             |                        ❌ |                        ❌ |                        ❌ |                        ❌ | ✅                        | 🟡                         |
 | Flux                     | ✅                        |                        ❌ |                        ❌ |                        ❌ |                        ❌ |                        ❌ |
 | GCMAES                   |                        ❌ |                        ❌ |                        ❌ |                        ❌ | ✅                        |                        ❌ |
-| MathOptInterface         | ✅                        | ✅                        | ✅                        | ✅                        | ✅                        |                        ❌ |
+| MathOptInterface         | ✅                        | ✅                        | ✅                        | ✅                        | ✅                        |                        🟡 |
 | MultistartOptimization   |                        ❌ |                        ❌ |                        ❌ |                        ❌ | ✅                        |                        ❌ |
 | Metaheuristics           |                        ❌ |                        ❌ |                        ❌ |                        ❌ | ✅                        | 🟡                         |
 | NOMAD                    |                        ❌ |                        ❌ |                        ❌ |                        ❌ | ✅                        | 🟡                         |


### PR DESCRIPTION
Based on my understanding of "Global Constrained" I propose to change this from "not supported" to "supported in downstream library but not yet implemented".

Examples of MOI solvers that support global optimization with constraints for MINLP are Alpine, BARON, Couenne (via AmplNLWriter), SCIP; and MIQCQP with Guorbi.  There are probably more but these are the ones that come to mind off the top of my head.

CC @odow 