### PR TITLE
Add mtk.jl for `AutoModelingToolkit` as AD backend support

### DIFF
--- a/lib/GalacticOptimJL/Project.toml
+++ b/lib/GalacticOptimJL/Project.toml
@@ -9,16 +9,17 @@ Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
-julia = "1"
 GalacticOptim = "3"
 Optim = "1"
 Reexport = "1.2"
+julia = "1"
 
 [extras]
+ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["ForwardDiff", "Random", "Test", "Zygote"]
+test = ["ForwardDiff", "ModelingToolkit", "Random", "Test", "Zygote"]

--- a/lib/GalacticOptimJL/test/runtests.jl
+++ b/lib/GalacticOptimJL/test/runtests.jl
@@ -23,6 +23,7 @@ using Test
 
     cons = (x, p) -> [x[1]^2 + x[2]^2]
     optprob = OptimizationFunction(rosenbrock, GalacticOptim.AutoForwardDiff(); cons=cons)
+    optprob = OptimizationFunction(rosenbrock, GalacticOptim.AutoModelingToolkit(); cons=cons)
 
     prob = OptimizationProblem(optprob, x0, _p)
 

--- a/lib/GalacticOptimJL/test/runtests.jl
+++ b/lib/GalacticOptimJL/test/runtests.jl
@@ -1,4 +1,4 @@
-using GalacticOptimJL, GalacticOptimJL.Optim, GalacticOptim, ForwardDiff, Zygote, Random
+using GalacticOptimJL, GalacticOptimJL.Optim, GalacticOptim, ForwardDiff, Zygote, Random, ModelingToolkit
 using Test
 
 @testset "GalacticOptimJL.jl" begin
@@ -89,5 +89,10 @@ using Test
     optprob = OptimizationFunction((x, p) -> -rosenbrock(x, p), GalacticOptim.AutoZygote(), grad=g!)
     prob = OptimizationProblem(optprob, x0, _p; sense=GalacticOptim.MaxSense)
     sol = solve(prob, BFGS())
+    @test 10 * sol.minimum < l1
+
+    optprob = OptimizationFunction(rosenbrock, GalacticOptim.AutoModelingToolkit())
+    prob = OptimizationProblem(optprob, x0, _p)
+    sol = solve(prob, Optim.BFGS())
     @test 10 * sol.minimum < l1
 end

--- a/src/GalacticOptim.jl
+++ b/src/GalacticOptim.jl
@@ -21,11 +21,12 @@ include("function/function.jl")
 
 function __init__()
     # AD backends
-    @require FiniteDiff="6a86dc24-6348-571c-b903-95158fe2bd41" include("function/finitediff.jl")
-    @require ForwardDiff="f6369f11-7733-5829-9624-2563aa707210" include("function/forwarddiff.jl")
-    @require ReverseDiff="37e2e3b7-166d-5795-8a7a-e32c996b4267" include("function/reversediff.jl")
-    @require Tracker="9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c" include("function/tracker.jl")
-    @require Zygote="e88e6eb3-aa80-5325-afca-941959d7151f" include("function/zygote.jl")
+    @require FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41" include("function/finitediff.jl")
+    @require ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210" include("function/forwarddiff.jl")
+    @require ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267" include("function/reversediff.jl")
+    @require Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c" include("function/tracker.jl")
+    @require Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f" include("function/zygote.jl")
+    @require ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78" include("function/mtk.jl")
 end
 
 export solve

--- a/src/function/forwarddiff.jl
+++ b/src/function/forwarddiff.jl
@@ -43,10 +43,8 @@ function instantiate_function(f::OptimizationFunction{true}, x, ::AutoForwardDif
 
     if f.cons === nothing
         cons = nothing
-        cons! = nothing
     else
         cons = θ -> f.cons(θ,p)
-        cons! = (res, θ) -> (res .= f.cons(θ,p); res)
     end
 
     if cons !== nothing && f.cons_j === nothing

--- a/src/function/mtk.jl
+++ b/src/function/mtk.jl
@@ -1,0 +1,60 @@
+struct AutoModelingToolkit <: AbstractADType end
+
+function instantiate_function(f, x, ::AutoModelingToolkit, p, num_cons=0)
+
+    sys = ModelingToolkit.modelingtoolkitize(OptimizationProblem(f, x, p))
+    println(sys)
+    if f.grad === nothing
+        grad_oop, grad_iip = ModelingToolkit.generate_gradient(sys, expression=Val{false})
+        grad(J, u) = (grad_iip(J, u, p); J)
+    else
+        grad = f.grad
+    end
+
+    if f.hess === nothing
+        hess_oop, hess_iip = ModelingToolkit.generate_hessian(sys, expression=Val{false})
+        hess(J, u) = (hess_iip(J, u, p); J)
+    else
+        hess = f.hess
+    end
+
+    if f.hv === nothing
+        hv = function (H, θ, v, args...)
+            res = ArrayInterface.zeromatrix(θ)
+            hess(res, θ, args...)
+            H .= res * v
+        end
+    else
+        hv = f.hv
+    end
+
+    if f.cons === nothing
+        cons = nothing
+    else
+        cons = (θ) -> f.cons(θ, p)
+        cons_sys = ModelingToolkit.modelingtoolkitize(OptimizationProblem(f.cons, x, p); checks=false)
+    end
+
+    if f.cons !== nothing && f.cons_j === nothing
+        cons_j = function (J, θ)
+            jac_oop, jac_iip = ModelingToolkit.generate_jacobian(cons_sys, expression=Val{false})
+            jac_iip(J, θ, p)
+        end
+    else
+        cons_j = f.cons_j
+    end
+
+    if f.cons !== nothing && f.cons_h === nothing
+        cons_h = function (res, θ)
+            for i in 1:num_cons
+                cons_sys_i = ModelingToolkit.modelingtoolkitize(OptimizationProblem((args...) -> f.cons(args...)[i], x, p); checks=false)
+                cons_hess_oop, cons_hess_iip = ModelingToolkit.generate_hessian(cons_sys_i, expression=Val{false})
+                cons_hess_iip(res[i], θ, p)
+            end
+        end
+    else
+        cons_h = f.cons_h
+    end
+
+    return OptimizationFunction{true,AutoModelingToolkit,typeof(f.f),typeof(grad),typeof(hess),typeof(hv),typeof(cons),typeof(cons_j),typeof(cons_h)}(f.f, AutoModelingToolkit(), grad, hess, hv, cons, cons_j, cons_h)
+end

--- a/src/function/mtk.jl
+++ b/src/function/mtk.jl
@@ -1,9 +1,9 @@
 struct AutoModelingToolkit <: AbstractADType end
 
 function instantiate_function(f, x, ::AutoModelingToolkit, p, num_cons=0)
-
+    p = isnothing(p) ? SciMLBase.NullParameters() : p
     sys = ModelingToolkit.modelingtoolkitize(OptimizationProblem(f, x, p))
-    println(sys)
+
     if f.grad === nothing
         grad_oop, grad_iip = ModelingToolkit.generate_gradient(sys, expression=Val{false})
         grad(J, u) = (grad_iip(J, u, p); J)

--- a/test/ADtests.jl
+++ b/test/ADtests.jl
@@ -1,8 +1,8 @@
 using GalacticOptim, GalacticOptimJL, GalacticFlux, Test
 using ForwardDiff, Zygote, ReverseDiff, FiniteDiff, Tracker
-
+using ModelingToolkit
 x0 = zeros(2)
-rosenbrock(x, p=nothing) =  (1 - x[1])^2 + 100 * (x[2] - x[1]^2)^2
+rosenbrock(x, p=nothing) = (1 - x[1])^2 + 100 * (x[2] - x[1]^2)^2
 l1 = rosenbrock(x0)
 
 function g!(G, x)
@@ -17,16 +17,24 @@ function h!(H, x)
     H[2, 2] = 200.0
 end
 
-G1 = Array{Float64}(undef,2)
-G2 = Array{Float64}(undef,2)
+G1 = Array{Float64}(undef, 2)
+G2 = Array{Float64}(undef, 2)
 H1 = Array{Float64}(undef, 2, 2)
 H2 = Array{Float64}(undef, 2, 2)
 
 g!(G1, x0)
 h!(H1, x0)
 
+cons = (x, p) -> [x[1]^2 + x[2]^2]
+optf = OptimizationFunction(rosenbrock, GalacticOptim.AutoModelingToolkit(), cons = cons)
+optprob = GalacticOptim.instantiate_function(optf, x0, GalacticOptim.AutoModelingToolkit(), nothing)
+optprob.grad(G2, x0)
+@test G1 == G2
+optprob.hess(H2, x0)
+@test H1 == H2
+
 optf = OptimizationFunction(rosenbrock, GalacticOptim.AutoForwardDiff())
-optprob = GalacticOptim.instantiate_function(optf,x0,GalacticOptim.AutoForwardDiff(),nothing)
+optprob = GalacticOptim.instantiate_function(optf, x0, GalacticOptim.AutoForwardDiff(), nothing)
 optprob.grad(G2, x0)
 @test G1 == G2
 optprob.hess(H2, x0)
@@ -35,16 +43,16 @@ optprob.hess(H2, x0)
 prob = OptimizationProblem(optprob, x0)
 
 sol = solve(prob, Optim.BFGS())
-@test 10*sol.minimum < l1
+@test 10 * sol.minimum < l1
 
 sol = solve(prob, Optim.Newton())
-@test 10*sol.minimum < l1
+@test 10 * sol.minimum < l1
 
 sol = solve(prob, Optim.KrylovTrustRegion())
-@test 10*sol.minimum < l1
+@test 10 * sol.minimum < l1
 
 optf = OptimizationFunction(rosenbrock, GalacticOptim.AutoZygote())
-optprob = GalacticOptim.instantiate_function(optf,x0,GalacticOptim.AutoZygote(),nothing)
+optprob = GalacticOptim.instantiate_function(optf, x0, GalacticOptim.AutoZygote(), nothing)
 optprob.grad(G2, x0)
 @test G1 == G2
 optprob.hess(H2, x0)
@@ -53,16 +61,16 @@ optprob.hess(H2, x0)
 prob = OptimizationProblem(optprob, x0)
 
 sol = solve(prob, Optim.BFGS())
-@test 10*sol.minimum < l1
+@test 10 * sol.minimum < l1
 
 sol = solve(prob, Optim.Newton())
-@test 10*sol.minimum < l1
+@test 10 * sol.minimum < l1
 
 sol = solve(prob, Optim.KrylovTrustRegion())
-@test 10*sol.minimum < l1
+@test 10 * sol.minimum < l1
 
 optf = OptimizationFunction(rosenbrock, GalacticOptim.AutoReverseDiff())
-optprob = GalacticOptim.instantiate_function(optf,x0,GalacticOptim.AutoReverseDiff(),nothing)
+optprob = GalacticOptim.instantiate_function(optf, x0, GalacticOptim.AutoReverseDiff(), nothing)
 optprob.grad(G2, x0)
 @test G1 == G2
 optprob.hess(H2, x0)
@@ -70,16 +78,16 @@ optprob.hess(H2, x0)
 
 prob = OptimizationProblem(optprob, x0)
 sol = solve(prob, Optim.BFGS())
-@test 10*sol.minimum < l1
+@test 10 * sol.minimum < l1
 
 sol = solve(prob, Optim.Newton())
-@test 10*sol.minimum < l1
+@test 10 * sol.minimum < l1
 
 sol = solve(prob, Optim.KrylovTrustRegion())
-@test 10*sol.minimum < l1
+@test 10 * sol.minimum < l1
 
 optf = OptimizationFunction(rosenbrock, GalacticOptim.AutoTracker())
-optprob = GalacticOptim.instantiate_function(optf,x0,GalacticOptim.AutoTracker(),nothing)
+optprob = GalacticOptim.instantiate_function(optf, x0, GalacticOptim.AutoTracker(), nothing)
 optprob.grad(G2, x0)
 @test G1 == G2
 @test_throws ErrorException optprob.hess(H2, x0)
@@ -88,26 +96,26 @@ optprob.grad(G2, x0)
 prob = OptimizationProblem(optprob, x0)
 
 sol = solve(prob, Optim.BFGS())
-@test 10*sol.minimum < l1
+@test 10 * sol.minimum < l1
 
 @test_throws ErrorException solve(prob, Newton())
 
 optf = OptimizationFunction(rosenbrock, GalacticOptim.AutoFiniteDiff())
-optprob = GalacticOptim.instantiate_function(optf,x0,GalacticOptim.AutoFiniteDiff(),nothing)
+optprob = GalacticOptim.instantiate_function(optf, x0, GalacticOptim.AutoFiniteDiff(), nothing)
 optprob.grad(G2, x0)
-@test G1 ≈ G2 rtol=1e-6
+@test G1 ≈ G2 rtol = 1e-6
 optprob.hess(H2, x0)
-@test H1 ≈ H2 rtol=1e-6
+@test H1 ≈ H2 rtol = 1e-6
 
 prob = OptimizationProblem(optprob, x0)
 sol = solve(prob, Optim.BFGS())
-@test 10*sol.minimum < l1
+@test 10 * sol.minimum < l1
 
 sol = solve(prob, Optim.Newton())
-@test 10*sol.minimum < l1
+@test 10 * sol.minimum < l1
 
 sol = solve(prob, Optim.KrylovTrustRegion())
 @test sol.minimum < l1 #the loss doesn't go below 5e-1 here
 
-sol = solve(prob, Flux.ADAM(0.1), maxiters = 1000)
-@test 10*sol.minimum < l1
+sol = solve(prob, Flux.ADAM(0.1), maxiters=1000)
+@test 10 * sol.minimum < l1


### PR DESCRIPTION
This PR moves implementation of `AutoModelingToolkit` to similar interface as the other AD backends and also adds support for constraints.