### PR TITLE
Update Project.toml

### DIFF
--- a/lib/GalacticMultistartOptimization/Project.toml
+++ b/lib/GalacticMultistartOptimization/Project.toml
@@ -10,7 +10,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
 julia = "1"
-MultistartOptimization = "0.1"
+MultistartOptimization = "0.1.3"
 GalacticOptim = "3"
 Reexport = "1.2"
 


### PR DESCRIPTION
Add specific compat version requirement for MultistartOptimization.jl because only 0.1.3 implements the generic API which allows us to pass GalacticOptim optimisers to the MultistartOptimization algorithm.